### PR TITLE
[FIX] no space between pagination and footer on search page (Podio bu…

### DIFF
--- a/dev/styles/main/plugins/search/search.less
+++ b/dev/styles/main/plugins/search/search.less
@@ -60,6 +60,11 @@
 .search-result-pagination {
     margin-top: 20px;
 }
+
+.search-result-pagination:last-child {
+    margin-bottom: 20px;
+}
+
 .search-result-pagination .btn-default {
     background: darken(@main-body-bg, 10%);
     color: @main-text-color;


### PR DESCRIPTION
…g_35)
<img width="936" alt="screen shot 2016-12-12 at 17 25 35" src="https://cloud.githubusercontent.com/assets/17538897/21104788/88fa8a36-c090-11e6-86a1-1792fca9bb2d.png">

add 20px of space between pagination and footer of search page